### PR TITLE
fix: 修复navigation.reset的时候，页面进入动画方向与IOS不一致的问题

### DIFF
--- a/tester/harmony/screens/src/main/ets/components/RNSScreenStack.ets
+++ b/tester/harmony/screens/src/main/ets/components/RNSScreenStack.ets
@@ -52,6 +52,11 @@ export struct RNSScreenStack {
   static RECORD_PRESENTATION: string = "push";
   static ROOT_TAG: number = 0;
   static STATUS_BAR_HEIGHT: number = 0;
+  @State isReset: boolean = false;
+  
+  arrayContainsArray(source: number[], target: number[]): boolean {
+    return target.every(item => source.includes(item));
+  }
 
   updateStack(newChildren: number[]) {
     if (!newChildren || this.stack.length === 0) {
@@ -75,8 +80,19 @@ export struct RNSScreenStack {
       return;
     }
 
-    if (newChildren.length < this.stack.length) {
+    if (newChildren.length < this.stack.length && this.arrayContainsArray(this.stack,newChildren)) {
       this.stackController.popToIndex(differentElementIndex === -1 ? newChildren.length - 1 : differentElementIndex - 1)
+    }
+
+    if(differentElementIndex === 0){
+      this.stackController.clear();
+
+      for (let i = differentElementIndex; i < newChildren.length; i++) {
+        console.info('test zyx stack update reset path name:' + newChildren[i].toString());
+        this.stackController.pushPathByName(newChildren[i].toString(), null)
+      }
+      this.isReset = true;
+      return;
     }
 
     if (differentElementIndex !== -1) {
@@ -198,9 +214,16 @@ export struct RNSScreenStack {
             enteringScreenAnimation = toParam.showAnimation;
             animationType = fromParam.getAnimationType();
           } else {
-            exitingScreenAnimation = fromParam.hideAnimation;
-            enteringScreenAnimation = toParam.attachAnimation;
-            animationType = toParam.getAnimationType();
+            if(this.isReset){
+              exitingScreenAnimation = fromParam.detachAnimation;
+              enteringScreenAnimation = toParam.showAnimation;
+              animationType = fromParam.getAnimationType();
+              this.isReset = false;
+            } else {
+              exitingScreenAnimation = fromParam.hideAnimation;
+              enteringScreenAnimation = toParam.attachAnimation;
+              animationType = toParam.getAnimationType();
+            }
           }
         } else if (operation == NavigationOperation.PUSH && this.replaceAnimation === 'push') {
           RNSScreenStack.RECORD_PRESENTATION = this.presentation;


### PR DESCRIPTION
# Summary

- 修复navigation.reset的时候，页面进入动画方向与IOS不一致的问题。


## Test Plan

![image](https://github.com/user-attachments/assets/363830e0-5fa0-42e5-8df4-01e7c2e15271)
![image](https://github.com/user-attachments/assets/2d9c386f-25df-433e-8a63-a822b71f3256)


## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

