### PR TITLE
fix: 修复使用navigation.reset有固定页面key值时，页面返回时白屏异常问题

### DIFF
--- a/tester/harmony/build-profile.json5
+++ b/tester/harmony/build-profile.json5
@@ -5,7 +5,6 @@
         name: 'default',
         signingConfig: 'default',
         compatibleSdkVersion: '5.0.0(12)',
-        runtimeOS: 'HarmonyOS',
       },
     ],
     buildModeSet: [

--- a/tester/harmony/screens/BuildProfile.ets
+++ b/tester/harmony/screens/BuildProfile.ets
@@ -1,7 +1,7 @@
 /**
  * Use these variables when you tailor your ArkTS code. They must be of the const type.
  */
-export const HAR_VERSION = '3.34.0-rc.0';
+export const HAR_VERSION = '3.34.0-rc.1';
 export const BUILD_MODE_NAME = 'debug';
 export const DEBUG = true;
 export const TARGET_NAME = 'default';

--- a/tester/harmony/screens/build-profile.json5
+++ b/tester/harmony/screens/build-profile.json5
@@ -3,7 +3,6 @@
   "targets": [
     {
       "name": "default",
-      "runtimeOS": "HarmonyOS"
     },
     {
       "name": "ohosTest",

--- a/tester/harmony/screens/src/main/ets/components/RNSScreenStack.ets
+++ b/tester/harmony/screens/src/main/ets/components/RNSScreenStack.ets
@@ -54,10 +54,6 @@ export struct RNSScreenStack {
   static STATUS_BAR_HEIGHT: number = 0;
   @State isReset: boolean = false;
   
-  arrayContainsArray(source: number[], target: number[]): boolean {
-    return target.every(item => source.includes(item));
-  }
-
   updateStack(newChildren: number[]) {
     if (!newChildren || this.stack.length === 0) {
       for (let i = 0; i < newChildren.length; i++) {
@@ -80,7 +76,7 @@ export struct RNSScreenStack {
       return;
     }
 
-    if (newChildren.length < this.stack.length && this.arrayContainsArray(this.stack,newChildren)) {
+    if (newChildren.length === this.stack.length-1 && JSON.stringify(newChildren) === JSON.stringify(this.stack.slice(0, this.stack.length-1))) {
       this.stackController.popToIndex(differentElementIndex === -1 ? newChildren.length - 1 : differentElementIndex - 1)
     }
 
@@ -88,7 +84,6 @@ export struct RNSScreenStack {
       this.stackController.clear();
 
       for (let i = differentElementIndex; i < newChildren.length; i++) {
-        console.info('test zyx stack update reset path name:' + newChildren[i].toString());
         this.stackController.pushPathByName(newChildren[i].toString(), null)
       }
       this.isReset = true;
@@ -96,8 +91,16 @@ export struct RNSScreenStack {
     }
 
     if (differentElementIndex !== -1) {
-      for (let i = differentElementIndex; i < newChildren.length; i++) {
-        this.stackController.pushPathByName(newChildren[i].toString(), null)
+      if (newChildren.length -1 === this.stack.length && JSON.stringify(this.stack) === JSON.stringify(newChildren.slice(0, newChildren.length-1))) {
+        for (let i = differentElementIndex; i < newChildren.length; i++) {
+          this.stackController.pushPathByName(newChildren[i].toString(), null)
+        }
+      } else {
+        this.stackController.popToIndex(differentElementIndex === -1 ? newChildren.length - 1 : differentElementIndex - 1)
+        for (let i = differentElementIndex; i < newChildren.length; i++) {
+          this.stackController.pushPathByName(newChildren[i].toString(), null)
+        }
+        this.isReset = true;
       }
     }
   }


### PR DESCRIPTION
# Summary

修复使用navigation.reset有固定页面key值时，页面返回时白屏异常问题

## Test Plan

![image](https://github.com/user-attachments/assets/363830e0-5fa0-42e5-8df4-01e7c2e15271)
![image](https://github.com/user-attachments/assets/2d9c386f-25df-433e-8a63-a822b71f3256)

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
