### PR TITLE
fix: 修复使用navigation.pop(2) pop多页面栈异常，代码补充提交

### DIFF
--- a/tester/harmony/screens/src/main/ets/components/RNSScreenStack.ets
+++ b/tester/harmony/screens/src/main/ets/components/RNSScreenStack.ets
@@ -77,7 +77,7 @@ export struct RNSScreenStack {
       return;
     }
 
-    if (newChildren.length !== -1 && newChildren.length === this.stack.length-1 && JSON.stringify(newChildren) === JSON.stringify(this.stack.slice(0, this.stack.length-1))) {
+    if (newChildren.length !== -1 && differentElementIndex === -1 && JSON.stringify(newChildren) === JSON.stringify(this.stack.slice(0, newChildren.length))) {
       this.stackController.popToIndex(differentElementIndex === -1 ? newChildren.length - 1 : differentElementIndex - 1)
     }
 


### PR DESCRIPTION
# Summary

修复使用navigation.pop(2) pop多页面栈异常，代码补充提交

## Test Plan

![20250416212733](https://github.com/user-attachments/assets/2a8799d1-3396-46ea-bc6d-d0c80183f27a)

![image](https://github.com/user-attachments/assets/bfea88bb-8413-49bd-ae68-1594fa53e8c2)

![3c8efab311baf2c2200116b449b9dcb](https://github.com/user-attachments/assets/468d23cf-33b1-4bfd-bd8c-6109f91c0f1e)

![811ceecabf0fa6540bf2afb1c9a6c53](https://github.com/user-attachments/assets/a2cbea43-725b-4abe-96ff-9cfc3f3f65db)

![47d59d5c9dbfdc6b9931c43122df526](https://github.com/user-attachments/assets/4795b5b7-c4cc-46ab-9b8f-a1c776808be0)

![16b29467a2964f47e8cea9fee38e3a5](https://github.com/user-attachments/assets/788bc009-cc71-4aab-a1bd-b7c3a8eb1bb3)


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

