### PR TITLE
fix:页面切换时进场和出场动画整体平移改为层叠进入或者退出效果，与IOS保持一致

### DIFF
--- a/tester/harmony/screens/src/main/ets/animations/AnimationHandler.ets
+++ b/tester/harmony/screens/src/main/ets/animations/AnimationHandler.ets
@@ -70,7 +70,7 @@ function getAnimationConfigurationObject(animationType: string): AnimationConfig
     case 'fade_from_bottom':
       return fadeFromBottom;
     case 'ios':
-      return iosAnimation;
+      return slideFromRight;
     case 'none':
       return noneAnimation;
     case 'fade':

--- a/tester/harmony/screens/src/main/ets/components/RNSScreenStack.ets
+++ b/tester/harmony/screens/src/main/ets/components/RNSScreenStack.ets
@@ -54,7 +54,7 @@ export struct RNSScreenStack {
   static STATUS_BAR_HEIGHT: number = 0;
   @State isReset: boolean = false;
   @State isResetAnimationPush: boolean = true;
-  
+
   updateStack(newChildren: number[]) {
     if (!newChildren || this.stack.length === 0) {
       for (let i = 0; i < newChildren.length; i++) {
@@ -196,9 +196,9 @@ export struct RNSScreenStack {
       return undefined;
     }
 
-//    if (this.shouldFallbackToDefaultAnimation(operation, from, to)) {
-//      return undefined;
-//    }
+    //    if (this.shouldFallbackToDefaultAnimation(operation, from, to)) {
+    //      return undefined;
+    //    }
 
     this.customTransitionCoordinator.operation = operation;
     return {
@@ -211,70 +211,58 @@ export struct RNSScreenStack {
         // Obtain the corresponding transition animation callback from the customTransitionCoordinator class based on the sequence of subpages.
         let fromParam: AnimateCallback = this.customTransitionCoordinator.getAnimateParam(from.navDestinationId);
         let toParam: AnimateCallback = this.customTransitionCoordinator.getAnimateParam(to.navDestinationId);
-        let exitingScreenAnimation: AnimationDefinition;
-        let enteringScreenAnimation: AnimationDefinition;
+        let currentAnimation: AnimationDefinition;
         let animationType: string
 
         if (operation == NavigationOperation.PUSH && this.replaceAnimation === 'pop') {
-          exitingScreenAnimation = fromParam.detachAnimation;
-          enteringScreenAnimation = toParam.showAnimation;
+          currentAnimation = toParam.detachAnimation;
           animationType = fromParam.getAnimationType();
         } else if (operation == NavigationOperation.POP && this.replaceAnimation === 'push') {
           if ((RNSScreenStack.RECORD_PRESENTATION === 'transparentModal' || RNSScreenStack.RECORD_PRESENTATION === 'containedTransparentModal' || RNSScreenStack.RECORD_PRESENTATION === 'formSheet') && RNSScreenStack.RECORD_PRESENTATION !== this.presentation) {
             RNSScreenStack.RECORD_PRESENTATION = this.presentation
-            exitingScreenAnimation = fromParam.detachAnimation;
-            enteringScreenAnimation = toParam.showAnimation;
+            currentAnimation = toParam.showAnimation;
             animationType = fromParam.getAnimationType();
           } else {
             if(this.isReset){
               if (this.isResetAnimationPush) {
-                exitingScreenAnimation = fromParam.detachAnimation;
-                enteringScreenAnimation = toParam.showAnimation;
+                currentAnimation = toParam.showAnimation;
                 animationType = fromParam.getAnimationType();
               } else {
-                exitingScreenAnimation = fromParam.hideAnimation;
-                enteringScreenAnimation = toParam.attachAnimation;
+                currentAnimation = fromParam.hideAnimation;
                 animationType = toParam.getAnimationType();
               }
               this.isReset = false;
             } else {
-              exitingScreenAnimation = fromParam.hideAnimation;
-              enteringScreenAnimation = toParam.attachAnimation;
+              currentAnimation = fromParam.hideAnimation;
               animationType = toParam.getAnimationType();
             }
           }
         } else if (operation == NavigationOperation.PUSH && this.replaceAnimation === 'push') {
           RNSScreenStack.RECORD_PRESENTATION = this.presentation;
           if (this.presentation === 'transparentModal' || this.presentation === 'containedTransparentModal' || this.presentation === 'formSheet') {
-            exitingScreenAnimation = fromParam.hideAnimation;
-            enteringScreenAnimation = toParam.attachAnimation;
+            currentAnimation = fromParam.hideAnimation;
             animationType = toParam.getAnimationType();
           } else {
-            exitingScreenAnimation = fromParam.detachAnimation;
-            enteringScreenAnimation = toParam.showAnimation;
+            currentAnimation = toParam.showAnimation;
             animationType = fromParam.getAnimationType();
           }
         } else if (operation == NavigationOperation.POP && this.replaceAnimation === 'pop') {
-          exitingScreenAnimation = fromParam.hideAnimation;
-          enteringScreenAnimation = toParam.attachAnimation;
+          currentAnimation = fromParam.hideAnimation;
           animationType = toParam.getAnimationType();
         } else if (operation == NavigationOperation.REPLACE && this.replaceAnimation === 'push'){
-          exitingScreenAnimation = fromParam.detachAnimation;
-          enteringScreenAnimation = toParam.showAnimation;
+          currentAnimation = toParam.showAnimation;
           animationType = fromParam.getAnimationType();
         } else if (operation == NavigationOperation.REPLACE && this.replaceAnimation === 'pop'){
-          exitingScreenAnimation = fromParam.hideAnimation;
-          enteringScreenAnimation = toParam.attachAnimation;
+          currentAnimation = toParam.attachAnimation;
           animationType = fromParam.getAnimationType();
         } else {
-          exitingScreenAnimation = fromParam.detachAnimation;
-          enteringScreenAnimation = toParam.showAnimation;
+          currentAnimation = toParam.showAnimation;
           animationType = fromParam.getAnimationType();
         }
 
         const animationOptions = getAnimationConfig(animationType);
 
-        enteringScreenAnimation.start(animationType);
+        currentAnimation.start(animationType);
         animateTo({
           duration: animationOptions.duration,
           curve: animationOptions.curve,
@@ -284,19 +272,7 @@ export struct RNSScreenStack {
             this.eventEmitter!.emit("finishTransitioning", {})
           }
         }, () => {
-          enteringScreenAnimation.end(animationType);
-        })
-
-        exitingScreenAnimation.start(animationType);
-        animateTo({
-          duration: animationOptions.duration,
-          curve: animationOptions.curve,
-          tempo: animationOptions.tempo,
-          onFinish: () => {
-            transitionProxy.finishTransition();
-          }
-        }, () => {
-          exitingScreenAnimation.end(animationType);
+          currentAnimation.end(animationType);
         })
       }
     } as NavigationAnimatedTransition;


### PR DESCRIPTION
# Summary

- 页面切换时进场和出场动画整体平移改为层叠进入或者退出效果，与IOS保持一致。

## Test Plan

![image](https://github.com/user-attachments/assets/d171bc0e-980c-420f-81d2-6dce280b0aaa)
![image](https://github.com/user-attachments/assets/f4d042e8-d654-477e-bbd0-b2d4d744a7d9)


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)
