### PR TITLE
feat: 标题栏阴影效果和gestureEnable滑动动画跟手代码提交

### DIFF
--- a/tester/harmony/screens/src/main/ets/animations/CustomTransition.ets
+++ b/tester/harmony/screens/src/main/ets/animations/CustomTransition.ets
@@ -37,12 +37,14 @@ export interface AnimateCallback {
   detachAnimation: AnimationDefinition,
   hideAnimation: AnimationDefinition,
   showAnimation: AnimationDefinition,
+  interactive: ((operation: NavigationOperation) => void | undefined) | undefined;
 }
 
 export class CustomTransitionCoordinator {
   proxy: NavigationTransitionProxy | undefined = undefined;
   operation: NavigationOperation = NavigationOperation.PUSH
   private customTransitionMap: Map<string, AnimateCallback> = new Map();
+  interactive: boolean = false;
 
   // Passing the callbacks in the object breaks animateTo
   registerNavParam(name: string,
@@ -55,6 +57,7 @@ export class CustomTransitionCoordinator {
     showAnimationEndCallback: AnimationCallback,
     hideAnimationStartCallback: AnimationCallback,
     hideAnimationEndCallback: AnimationCallback,
+    interactiveCallback: (operation: NavigationOperation) => void,
   ): void {
     let paramToStore: AnimateCallback = {
       getAnimationType,
@@ -73,7 +76,8 @@ export class CustomTransitionCoordinator {
       hideAnimation: {
         start: hideAnimationStartCallback,
         end: hideAnimationEndCallback,
-      }
+      },
+      interactive: interactiveCallback
     }
     if (this.customTransitionMap.has(name)) {
       let param = this.customTransitionMap.get(name);
@@ -109,5 +113,13 @@ export class CustomTransitionCoordinator {
 
   getAnimateParam(name: string): AnimateCallback {
     return this.customTransitionMap.get(name)!;
+  }
+
+  fireInteractiveAnimation(name: string, operation: NavigationOperation) {
+    let animation = this.customTransitionMap.get(name)?.interactive;
+    if (!animation) {
+      return;
+    }
+    animation(operation);
   }
 }

--- a/tester/harmony/screens/src/main/ets/components/RNSScreen.ets
+++ b/tester/harmony/screens/src/main/ets/components/RNSScreen.ets
@@ -37,8 +37,8 @@ import { AnimationHandlerEvent, getNewAnimationState } from '../animations/Anima
 import { RNSScreenTitleHeader } from "./RNSScreenTitleHeader"
 import { TITLEBAR_HEIGHT } from '../Constants';
 import common from '@ohos.app.ability.common';
-import i18n from '@ohos.i18n';
 import { RNSScreenStack } from './RNSScreenStack'
+import { I18nManagerTurboModule } from '@rnoh/react-native-openharmony/src/main/ets/RNOHCorePackage/turboModules/index'
 
 export type RNSScreenDescriptor = Descriptor<"RNSScreen", RNC.RNSScreen.Props>
 
@@ -387,6 +387,11 @@ export struct RNSScreen {
       (animationType) => this.handleAnimation(animationType, AnimationHandlerEvent.SHOW_END),
       (animationType) => this.handleAnimation(animationType, AnimationHandlerEvent.HIDE_START),
       (animationType) => this.handleAnimation(animationType, AnimationHandlerEvent.HIDE_END),
+      (operation: NavigationOperation) => {
+        if (operation == NavigationOperation.PUSH) {
+        } else {
+        }
+      }
     )
   }
   private setScreenOrientation() {
@@ -425,14 +430,8 @@ export struct RNSScreen {
   
   private isRtl() {
     let flag: boolean = false;
-    if (this.directions) {
-      if (this.directions === 'rtl') {
-        flag = true;
-      } else if (this.directions === 'ltr') {
-        flag = false;
-      }
-    }
-    return flag;
+    const isRTL = this.ctx.rnInstance.getTurboModule<I18nManagerTurboModule>('I18nManager').getConstants() .isRTL;
+    return isRTL;
   }
   
   private isInGestureResponseDistance(event: GestureEvent): boolean {
@@ -465,7 +464,7 @@ export struct RNSScreen {
     {
       let isRTL = this.isRtl();
       let isSlideFromLeft: boolean = this.stackAnimation === "slide_from_left";
-      let isCorrectEdge: boolean = (isRTL && event.offsetX < 0 ) || (!isRTL && isSlideFromLeft && event.offsetX < 0) || (isRTL && isSlideFromLeft && event.offsetX > 0) || (!isRTL && event.offsetX > 0)
+      let isCorrectEdge: boolean = (isRTL && !isSlideFromLeft && event.offsetX < 0 ) || (!isRTL && isSlideFromLeft && event.offsetX < 0) || (isRTL && isSlideFromLeft && event.offsetX > 0) || (!isRTL && !isSlideFromLeft && event.offsetX > 0)
       if (isCorrectEdge) {
         flag = true
         return flag;
@@ -489,20 +488,30 @@ export struct RNSScreen {
       this.velocity = event.offsetX;
       this.distance= event.target.area.width as number;
       let isRTL = this.isRtl();
+      let isSlideFromLeft: boolean = this.stackAnimation === "slide_from_left";
       if (isRTL) {
         this.translation = -this.translation;
         this.velocity = -this.velocity;
         this.offsetX = this.positionX + event.offsetX;
+        if (!isSlideFromLeft){
+          this.translateXValue = this.offsetX.toString();
+        } else {
+          this.translateXValue = (-this.offsetX).toString();
+        }
       } else  {
         this.offsetX = this.positionX + event.offsetX;
+        if (!isSlideFromLeft){
+          this.translateXValue = this.offsetX.toString();
+        } else {
+          this.translateXValue = (-this.offsetX).toString();
+        }
       }
-      this.translateXValue = this.offsetX.toString();
     }
 
     let isInverted: boolean = this.stackAnimation === "slide_from_left";
     let transitionProgress: number = (this.translation / this.distance);
     transitionProgress = isInverted ? transitionProgress * -1 : transitionProgress;
-    this.eventEmitter!.emit("transitionProgress", {progress: transitionProgress, closing: true ? 1 : 0, goingForward: false ? 1 : 0})
+    this.eventEmitter!.emit("transitionProgress", {progress: transitionProgress, closing: 0, goingForward: 0})
     this.customTransitionCoordinator.updateProgress(transitionProgress);
   }
 
@@ -603,6 +612,10 @@ export struct RNSScreen {
           this.couldSwipe = this.gestureRecognizerShouldBegin(event)
           if (this.couldSwipe) {
             this.isInverted = this.stackAnimation === "slide_from_left";
+            this.customTransitionCoordinator.interactive = true;
+            if (Math.abs(event.offsetX) > 0) {
+              this.stackController?.pop()
+            }
           }
         })
         .onActionUpdate((event: GestureEvent) => {
@@ -613,7 +626,13 @@ export struct RNSScreen {
         .onActionCancel(() => {
           this.couldSwipe = false;
           this.eventEmitter!.emit("gestureCancel", {})
-          this.customTransitionCoordinator.cancelTransition();
+          if (this.customTransitionCoordinator.interactive) {
+            this.customTransitionCoordinator.interactive = false;
+            this.customTransitionCoordinator.cancelTransition();
+            this.eventEmitter!.emit("nativeDismissCancelled", {
+              dismissCount: 0
+            })
+          }
         })
         .onActionEnd((event: GestureEvent) => {
           if (this.couldSwipe) {
@@ -634,6 +653,9 @@ export struct RNSScreen {
               this.translateYValue = '0';
               this.customTransitionCoordinator.cancelTransition();
               this.eventEmitter!.emit("gestureCancel", {})
+              this.eventEmitter!.emit("nativeDismissCancelled", {
+                dismissCount: 0
+              })
             }
           }
           this.offsetY = 0;

--- a/tester/harmony/screens/src/main/ets/components/RNSScreenStack.ets
+++ b/tester/harmony/screens/src/main/ets/components/RNSScreenStack.ets
@@ -201,6 +201,25 @@ export struct RNSScreenStack {
     //    }
 
     this.customTransitionCoordinator.operation = operation;
+    if (this.customTransitionCoordinator.interactive) {
+      let customAnimation: NavigationAnimatedTransition = {
+        onTransitionEnd: (isSuccess: boolean) => {
+          this.customTransitionCoordinator.proxy = undefined;
+          this.customTransitionCoordinator.interactive = false;
+        },
+        transition: (transitionProxy: NavigationTransitionProxy) => {
+          this.customTransitionCoordinator.proxy = transitionProxy;
+          let targetIndex: string | undefined = operation == NavigationOperation.PUSH ?
+            (to.navDestinationId) : (from.navDestinationId);
+          if (targetIndex) {
+            this.customTransitionCoordinator.fireInteractiveAnimation(targetIndex, operation);
+          }
+        },
+        isInteractive: this.customTransitionCoordinator.interactive
+      }
+      return customAnimation;
+    }
+
     return {
       timeout: 2000, // The limit duration of the transition animation
       transition: (transitionProxy: NavigationTransitionProxy) => {

--- a/tester/harmony/screens/src/main/ets/components/RNSScreenTitleHeader.ets
+++ b/tester/harmony/screens/src/main/ets/components/RNSScreenTitleHeader.ets
@@ -132,7 +132,7 @@ export struct RNSScreenTitleHeader {
   }
 
   build() {
-    Column() {
+    RelativeContainer() {
       Stack() {
         Row() {
           if (!this.isFirstScreenInStack) {
@@ -188,6 +188,17 @@ export struct RNSScreenTitleHeader {
       .layoutWeight(1)
       .padding({ left: 10, right: 10 })
       .backgroundColor(this.titleBarTranslucent?Color.Transparent:this.backgroundColorValue)
+
+      Text('')
+        .width("100%")
+        .height("1")
+        .backgroundColor('#d3d3d3')
+        .visibility(this.hideShadow ? Visibility.None : Visibility.Visible)
+        .alignRules({
+          start: { anchor: "__container__", align: HorizontalAlign.Start },
+          top: { anchor: "__container__", align: VerticalAlign.Bottom }
+        })
+
     }
     .width("100%")
     .height(56)


### PR DESCRIPTION
# Summary
feat: 标题栏阴影效果和gestureEnable滑动动画跟手代码提交


## Test Plan
![44fba25122753aff773307c5a48d428](https://github.com/user-attachments/assets/8b0610e3-fb24-4c28-bfb5-bdc11de2960a)
![95777873497a7f82c68bc9536a9582f](https://github.com/user-attachments/assets/78492449-ef3a-4276-855f-fa864d8af110)

![bb770ae6dcb1d384344b1d0fa1cfa93](https://github.com/user-attachments/assets/3ccae973-a5f3-4fee-83b2-554698969bf0)


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

