### PR TITLE
fix: SearchBar onClose方法无效处理

### DIFF
--- a/tester/apps/src/screens/SearchBar.tsx
+++ b/tester/apps/src/screens/SearchBar.tsx
@@ -77,7 +77,10 @@ const MainScreen = ({navigation}: MainScreenProps): React.JSX.Element => {
         },
         onCancelButtonPress: () => {
           console.info('test screen searchBar onCancelButtonPress')
-          setMethodText('screen searchBar onCancelButtonPress')
+	  if (!log.includes('onCancelButtonPress')) {
+            log = ' onCancelButtonPress'
+          }
+          setMethodText('screen searchBar '+log)
         },
           // toast.push({
           //   message: '[iOS] Cancel button pressed',
@@ -85,7 +88,10 @@ const MainScreen = ({navigation}: MainScreenProps): React.JSX.Element => {
           // }),
         onClose: () => {
           console.info('test screen searchBar onClose')
-          setMethodText('screen searchBar onClose')
+          if (!log.includes('onClose')) {
+            log += ' onClose'
+          }
+          setMethodText('screen searchBar '+log)
         },
           // toast.push({
           //   message: '[Android] Closing',
@@ -93,6 +99,7 @@ const MainScreen = ({navigation}: MainScreenProps): React.JSX.Element => {
           // }),
         onOpen: () => {
           console.info('test screen searchBar onOpen')
+	  log = ''
           setMethodText('screen searchBar onOpen')
         },
           // toast.push({

--- a/tester/harmony/screens/src/main/ets/components/RNSSearchBar.ets
+++ b/tester/harmony/screens/src/main/ets/components/RNSSearchBar.ets
@@ -143,6 +143,7 @@ export struct RNSSearchBar {
   cancelSearch() {
     this.eventEmitter!.emit("cancelButtonPress", {})
     this.showTextInput = false;
+    this.eventEmitter!.emit("close", {})
   }
 
   build() {


### PR DESCRIPTION

# Summary
fix: SearchBar onClose方法无效处理

## Test Plan
![27296b0ab06123d376b95504ee1512d](https://github.com/user-attachments/assets/9be8fb5a-df11-4ccc-9878-dc6171264789)
![2b52ebc725670b8165656ae1ae2ea5a](https://github.com/user-attachments/assets/f423a6e4-0c0c-4be8-ad30-78798ca50626)


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
