### PR TITLE
feat: 实现blurEffect属性功能

### DIFF
--- a/tester/apps/src/screens/HeaderOptions.tsx
+++ b/tester/apps/src/screens/HeaderOptions.tsx
@@ -66,7 +66,7 @@ const SettingsScreen = ({
   const [headerShadowVisible, setHeaderShadowVisible] = useState(false);
   const [headerTransparent, setHeaderTransparent] = useState(false);
   const [headerBlurEffect, setHeaderBlurEffect] =
-    useState<BlurEffectTypes>('extraLight');
+    useState<BlurEffectTypes>('none');
 
   const [backgroundColor, setBackgroundColor] = useState('#0000ff');  
   const [color, setColor] = useState('#FF69B4');
@@ -236,6 +236,7 @@ const SettingsScreen = ({
         label="Header blur effect"
         value={headerBlurEffect}
         items={[
+          'none',
           'extraLight',
           'light',
           'dark',
@@ -290,7 +291,7 @@ const App = (): React.JSX.Element => (
           headerBackTitle: 'Back',
           headerShadowVisible: false,
           headerTransparent: false,
-          headerBlurEffect: 'extraLight',
+          headerBlurEffect: 'none',
           headerStyle: {
             backgroundColor: '#0000ff',
           },

--- a/tester/harmony/screens/src/main/ets/components/RNSScreen.ets
+++ b/tester/harmony/screens/src/main/ets/components/RNSScreen.ets
@@ -124,6 +124,8 @@ export struct RNSScreen {
   @State sheetLargestUndimmedDetent: number = 0; // todo mark
   @State sheetInitialDetent: number = 0; // todo mark
   @State sheetElevation: number = 0; // todo mark
+  @State blurEffect: 'none' | 'extraLight' | 'light' | 'dark' | 'regular' | 'prominent' | 'systemUltraThinMaterial' | 'systemThinMaterial' | 'systemMaterial' | 'systemThickMaterial' | 'systemChromeMaterial' | 'systemUltraThinMaterialLight' | 'systemThinMaterialLight' | 'systemMaterialLight' | 'systemThickMaterialLight' | 'systemChromeMaterialLight' | 'systemUltraThinMaterialDark' | 'systemThinMaterialDark' | 'systemMaterialDark' | 'systemThickMaterialDark' | 'systemChromeMaterialDark' = 'none'; // todo mark
+  @State blueStyle: BlurStyle = BlurStyle.NONE;
 
   @State offsetX: number = 0;
   @State offsetY: number = 0;
@@ -329,6 +331,11 @@ export struct RNSScreen {
       this.titleBarBgColor = this.titleBarTranslucent?"#00000000":(this.titleBarBackgroundColor?this.titleBarBackgroundColor:"#00000000");
     }
 
+    if (this.blurEffect !== this.screenStackHeaderConfigDescriptor.rawProps["blurEffect"]) {
+      this.blurEffect = this.screenStackHeaderConfigDescriptor.rawProps["blurEffect"];
+    }
+
+    this.blurEffectConvert();
     this.updateNativeHeaderHeight();
   }
 
@@ -525,6 +532,45 @@ export struct RNSScreen {
     this.backPressed();
   }
 
+  blurEffectConvert(){
+    if(this.blurEffect){
+      switch(this.blurEffect) {
+        case 'none':
+          this.blueStyle = BlurStyle.NONE;
+          break;
+        case 'extraLight':
+          this.blueStyle = BlurStyle.BACKGROUND_THIN;
+          break;
+        case 'light':
+          this.blueStyle = BlurStyle.BACKGROUND_THICK;
+          break;
+        case 'dark':
+          this.blueStyle = BlurStyle.BACKGROUND_ULTRA_THICK;
+          break;
+        case 'regular':
+          this.blueStyle = BlurStyle.BACKGROUND_REGULAR;
+          break;
+        case 'prominent':
+        case 'systemMaterial':
+        case 'systemMaterialLight':
+        case 'systemMaterialDark':
+        case 'systemUltraThinMaterial':
+        case 'systemUltraThinMaterialLight':
+        case 'systemUltraThinMaterialDark':
+        case 'systemThinMaterial':
+        case 'systemThinMaterialLight':
+        case 'systemThinMaterialDark':
+        case 'systemThickMaterial':
+        case 'systemThickMaterialLight':
+        case 'systemThickMaterialDark':
+        case 'systemChromeMaterial':
+        case 'systemChromeMaterialLight':
+        case 'systemChromeMaterialDark':
+          this.ctx.logger.error('RNSScreenStackHeaderConfig', this.blurEffect+" not support")
+          break;
+      }
+    }
+  }
   @Builder
   screenTitleBuilder() {
     RNSScreenTitleHeader({
@@ -563,7 +609,7 @@ export struct RNSScreen {
       RNViewBase({ ctx: this.ctx, tag: this.tag }) {
         Stack() {
           if(this.isStatusBarShow) {
-            Text('').height(this.statusBarHeight).width('100%').backgroundColor(this.titleBarBgColor).position({x:0, y:0})
+            Text('').height(this.statusBarHeight).width('100%').backgroundColor(this.titleBarBgColor).position({x:0, y:0}).backgroundBlurStyle(this.blueStyle)
           }
 
           Stack(){

--- a/tester/harmony/screens/src/main/ets/components/RNSScreenTitleHeader.ets
+++ b/tester/harmony/screens/src/main/ets/components/RNSScreenTitleHeader.ets
@@ -49,6 +49,7 @@ export struct RNSScreenTitleHeader {
   @State backButtonInCustomView: boolean | undefined = undefined;
   @State titleBarTranslucent: boolean = false;
   @State blurEffect: 'none' | 'extraLight' | 'light' | 'dark' | 'regular' | 'prominent' | 'systemUltraThinMaterial' | 'systemThinMaterial' | 'systemMaterial' | 'systemThickMaterial' | 'systemChromeMaterial' | 'systemUltraThinMaterialLight' | 'systemThinMaterialLight' | 'systemMaterialLight' | 'systemThickMaterialLight' | 'systemChromeMaterialLight' | 'systemUltraThinMaterialDark' | 'systemThinMaterialDark' | 'systemMaterialDark' | 'systemThickMaterialDark' | 'systemChromeMaterialDark' = 'none'; // todo mark
+  @State blueStyle: BlurStyle = BlurStyle.NONE;
   private cleanUpCallbacks: (() => void)[] = []
   public backBtnPressed: () => void = () => {
   }
@@ -71,6 +72,45 @@ export struct RNSScreenTitleHeader {
     this.cleanUpCallbacks.forEach(cb => cb())
   }
 
+  blurEffectConvert(){
+    if(this.blurEffect){
+      switch(this.blurEffect) {
+        case 'none':
+          this.blueStyle = BlurStyle.NONE;
+          break;
+        case 'extraLight':
+          this.blueStyle = BlurStyle.BACKGROUND_THIN;
+          break;
+        case 'light':
+          this.blueStyle = BlurStyle.BACKGROUND_THICK;
+          break;
+        case 'dark':
+          this.blueStyle = BlurStyle.BACKGROUND_ULTRA_THICK;
+          break;
+        case 'regular':
+          this.blueStyle = BlurStyle.BACKGROUND_REGULAR;
+          break;
+        case 'prominent':
+        case 'systemMaterial':
+        case 'systemMaterialLight':
+        case 'systemMaterialDark':
+        case 'systemUltraThinMaterial':
+        case 'systemUltraThinMaterialLight':
+        case 'systemUltraThinMaterialDark':
+        case 'systemThinMaterial':
+        case 'systemThinMaterialLight':
+        case 'systemThinMaterialDark':
+        case 'systemThickMaterial':
+        case 'systemThickMaterialLight':
+        case 'systemThickMaterialDark':
+        case 'systemChromeMaterial':
+        case 'systemChromeMaterialLight':
+        case 'systemChromeMaterialDark':
+          this.ctx.logger.error('RNSScreenStackHeaderConfig', this.blurEffect+" not support")
+          break;
+      }
+    }
+  }
   updateState() {
     if (!this.descriptor) {
       return
@@ -137,6 +177,8 @@ export struct RNSScreenTitleHeader {
     if (this.blurEffect !== this.descriptor.rawProps["blurEffect"]) {
       this.blurEffect = this.descriptor.rawProps["blurEffect"];
     }
+
+    this.blurEffectConvert();
   }
 
   build() {
@@ -196,6 +238,7 @@ export struct RNSScreenTitleHeader {
       .layoutWeight(1)
       .padding({ left: 10, right: 10 })
       .backgroundColor(this.titleBarTranslucent?Color.Transparent:this.backgroundColorValue)
+      .backgroundBlurStyle(this.blueStyle)
 
       Text('')
         .width("100%")


### PR DESCRIPTION
# Summary

feat: 实现blurEffect属性功能


## Test Plan
<img width="296" height="644" alt="7b124dfe4bc258882cbfeccc8c148ff7" src="https://github.com/user-attachments/assets/7cea0f2e-1c19-47a6-a21d-7cced5c4d3a5" />
<img width="320" height="693" alt="7e4c5f5ef61d0f15253bc0edfc2cfffa" src="https://github.com/user-attachments/assets/f2b165f8-fa11-45ef-a70d-e4cd48cacbf4" />



## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

