### PR TITLE
feat: screens库RNSSearchBar的tintColor属性，RNSScreenStackHeaderConfig的color属性，RNSScreen的onHeaderBackButtonClicked回调功能补充实现

### DIFF
--- a/react-native-harmony-screens/src/gesture-handler/defaults.ts
+++ b/react-native-harmony-screens/src/gesture-handler/defaults.ts
@@ -22,7 +22,7 @@ export const DefaultEvent: GestureUpdateEvent<PanGestureHandlerEventPayload> = {
   // and they are required to specify. This should be backward
   // compatible unless they strictly parse the objects, which seems
   // not likely. PointerType is present since 2.16.0, StylusData since 2.20.0
-  pointerType: PointerType.TOUCH, // todo mark
+  pointerType: PointerType.TOUCH,
 };
 
 export const DefaultScreenDimensions = {

--- a/tester/apps/src/screens/HeaderOptions.tsx
+++ b/tester/apps/src/screens/HeaderOptions.tsx
@@ -70,6 +70,7 @@ const SettingsScreen = ({
 
   const [backgroundColor, setBackgroundColor] = useState('#0000ff');  
   const [color, setColor] = useState('#FF69B4');
+  const [titleColor, setTitleColor] = useState('#FF6900');
   const [fontSize, setFontSize] = useState(18);
   const [fontWeight, setFontWeight] = useState<FontWeight>('normal'); 
 
@@ -95,13 +96,14 @@ const SettingsScreen = ({
         backgroundColor,
       },
       headerTitleStyle:{
-        color,
+        color: titleColor,
         fontSize,
         fontWeight, 
       },
       headerBackTitleStyle: {
         fontSize
-      }
+      },
+      headerTintColor: color,
     });
   }, [
     navigation,
@@ -120,6 +122,7 @@ const SettingsScreen = ({
     color,
     fontSize,
     fontWeight,
+    titleColor,
   ]);
 
   return (
@@ -171,8 +174,7 @@ const SettingsScreen = ({
             setBackButtonVisible(false);
           }
           if (
-            item === 'center' &&
-            // Platform.OS === 'android' && // todo edit
+            item === 'center' &&            
             Platform.OS !== 'ios' &&
             headerTitleAlign !== 'center'
           ) {
@@ -195,6 +197,11 @@ const SettingsScreen = ({
       />
       <SettingsInput
         label="Header titleColor"
+        value={titleColor}
+        onValueChange={setTitleColor}
+      />
+      <SettingsInput
+        label="Header color"
         value={color}
         onValueChange={setColor}
       />

--- a/tester/apps/src/screens/SearchBar.tsx
+++ b/tester/apps/src/screens/SearchBar.tsx
@@ -51,7 +51,8 @@ const MainScreen = ({navigation}: MainScreenProps): React.JSX.Element => {
   const searchBarRef = useRef<SearchBarCommands>(null);
   const [textColor, setTextColor] = useState<BarTintColor>('#FFA500'); // 'white'
   const [cancelButtonText, setCancelButtonText] = useState('cancel');   
-  const [methodText, setMethodText] = useState('');  
+  const [methodText, setMethodText] = useState('');
+  const [tintColor, setTintColor] = useState<BarTintColor>('#FFA500'); // 'orange' 
   let log = '' 
 
   useLayoutEffect(() => {
@@ -70,6 +71,7 @@ const MainScreen = ({navigation}: MainScreenProps): React.JSX.Element => {
         inputType,
         textColor,
         cancelButtonText,
+        tintColor,
         onChangeText: event => {
           console.info('test screen searchBar onChangeText text:'+event.nativeEvent.text)
           setMethodText('screen searchBar onChangeText '+event.nativeEvent.text)
@@ -149,7 +151,8 @@ const MainScreen = ({navigation}: MainScreenProps): React.JSX.Element => {
     autoCapitalize,
     inputType,
     textColor, 
-    cancelButtonText
+    cancelButtonText,
+    tintColor
   ]);
 
   return (
@@ -248,6 +251,12 @@ const MainScreen = ({navigation}: MainScreenProps): React.JSX.Element => {
         label="cancelButtonText"
         value={cancelButtonText}
         onValueChange={setCancelButtonText}
+      />
+      <SettingsPicker<BarTintColor>      
+        label="Tint Color"
+        value={tintColor}
+        onValueChange={setTintColor}
+        items={['#FF7F50', '#FFA500', '#2F4F4F']}
       />
       <ThemedText style={styles.heading}>Other</ThemedText>
       <Button

--- a/tester/harmony/screens/src/main/cpp/generated/RNOH/generated/BaseReactNativeScreensPackage.h
+++ b/tester/harmony/screens/src/main/cpp/generated/RNOH/generated/BaseReactNativeScreensPackage.h
@@ -117,7 +117,6 @@ class BaseReactNativeScreensPackageEventEmitRequestHandler : public EventEmitReq
 
         if (std::find(supportedComponentNames.begin(), supportedComponentNames.end(), componentName) != supportedComponentNames.end() &&
             std::find(supportedEventNames.begin(), supportedEventNames.end(), ctx.eventName) != supportedEventNames.end()) { // todo mark 
-//        if (std::find(supportedEventNames.begin(), supportedEventNames.end(), ctx.eventName) != supportedEventNames.end()) { // todo test add            
             eventEmitter->dispatchEvent(ctx.eventName, ArkJS(ctx.env).getDynamic(ctx.payload));
         }    
     }

--- a/tester/harmony/screens/src/main/ets/components/RNSScreen.ets
+++ b/tester/harmony/screens/src/main/ets/components/RNSScreen.ets
@@ -120,11 +120,11 @@ export struct RNSScreen {
   @State opacityValue: number = 1;
   @State screenOrientation: string = 'default';
 
-  @State sheetAllowedDetents: number[] = []; // todo mark
-  @State sheetLargestUndimmedDetent: number = 0; // todo mark
-  @State sheetInitialDetent: number = 0; // todo mark
-  @State sheetElevation: number = 0; // todo mark
-  @State blurEffect: 'none' | 'extraLight' | 'light' | 'dark' | 'regular' | 'prominent' | 'systemUltraThinMaterial' | 'systemThinMaterial' | 'systemMaterial' | 'systemThickMaterial' | 'systemChromeMaterial' | 'systemUltraThinMaterialLight' | 'systemThinMaterialLight' | 'systemMaterialLight' | 'systemThickMaterialLight' | 'systemChromeMaterialLight' | 'systemUltraThinMaterialDark' | 'systemThinMaterialDark' | 'systemMaterialDark' | 'systemThickMaterialDark' | 'systemChromeMaterialDark' = 'none'; // todo mark
+  @State sheetAllowedDetents: number[] = [];
+  @State sheetLargestUndimmedDetent: number = 0;
+  @State sheetInitialDetent: number = 0;
+  @State sheetElevation: number = 0;
+  @State blurEffect: 'none' | 'extraLight' | 'light' | 'dark' | 'regular' | 'prominent' | 'systemUltraThinMaterial' | 'systemThinMaterial' | 'systemMaterial' | 'systemThickMaterial' | 'systemChromeMaterial' | 'systemUltraThinMaterialLight' | 'systemThinMaterialLight' | 'systemMaterialLight' | 'systemThickMaterialLight' | 'systemChromeMaterialLight' | 'systemUltraThinMaterialDark' | 'systemThinMaterialDark' | 'systemMaterialDark' | 'systemThickMaterialDark' | 'systemChromeMaterialDark' = 'none';
   @State blueStyle: BlurStyle = BlurStyle.NONE;
 
   @State offsetX: number = 0;
@@ -600,6 +600,7 @@ export struct RNSScreen {
         this.eventEmitter!.emit("dismissed", {
           dismissCount: this.dismissCount
         })
+        this.eventEmitter!.emit("headerBackButtonClicked", {});
       }
     }
   }

--- a/tester/harmony/screens/src/main/ets/components/RNSScreenContentWrapper.ets
+++ b/tester/harmony/screens/src/main/ets/components/RNSScreenContentWrapper.ets
@@ -23,7 +23,6 @@
  */
 
 import { Descriptor, RNComponentContext, } from '@rnoh/react-native-openharmony';
-// import { RNC } from "@rnoh/react-native-openharmony/generated" // todo del
 import { RNC }  from '../generated/ts';
 
 export type RNSScreenContentWrapperDescriptor = Descriptor<"RNSScreenContentWrapper", RNC.RNSScreenContentWrapper.Props>

--- a/tester/harmony/screens/src/main/ets/components/RNSScreenTitleHeader.ets
+++ b/tester/harmony/screens/src/main/ets/components/RNSScreenTitleHeader.ets
@@ -48,8 +48,9 @@ export struct RNSScreenTitleHeader {
   @State hideBackButton: boolean | undefined = undefined;
   @State backButtonInCustomView: boolean | undefined = undefined;
   @State titleBarTranslucent: boolean = false;
-  @State blurEffect: 'none' | 'extraLight' | 'light' | 'dark' | 'regular' | 'prominent' | 'systemUltraThinMaterial' | 'systemThinMaterial' | 'systemMaterial' | 'systemThickMaterial' | 'systemChromeMaterial' | 'systemUltraThinMaterialLight' | 'systemThinMaterialLight' | 'systemMaterialLight' | 'systemThickMaterialLight' | 'systemChromeMaterialLight' | 'systemUltraThinMaterialDark' | 'systemThinMaterialDark' | 'systemMaterialDark' | 'systemThickMaterialDark' | 'systemChromeMaterialDark' = 'none'; // todo mark
+  @State blurEffect: 'none' | 'extraLight' | 'light' | 'dark' | 'regular' | 'prominent' | 'systemUltraThinMaterial' | 'systemThinMaterial' | 'systemMaterial' | 'systemThickMaterial' | 'systemChromeMaterial' | 'systemUltraThinMaterialLight' | 'systemThinMaterialLight' | 'systemMaterialLight' | 'systemThickMaterialLight' | 'systemChromeMaterialLight' | 'systemUltraThinMaterialDark' | 'systemThinMaterialDark' | 'systemMaterialDark' | 'systemThickMaterialDark' | 'systemChromeMaterialDark' = 'none';
   @State blueStyle: BlurStyle = BlurStyle.NONE;
+  @State hintColor: string | undefined = undefined;
   private cleanUpCallbacks: (() => void)[] = []
   public backBtnPressed: () => void = () => {
   }
@@ -178,6 +179,10 @@ export struct RNSScreenTitleHeader {
       this.blurEffect = this.descriptor.rawProps["blurEffect"];
     }
 
+    if (this.hintColor !== this.descriptor.rawProps["color"]) {
+      this.hintColor = this.descriptor.rawProps["color"]
+    }
+
     this.blurEffectConvert();
   }
 
@@ -188,13 +193,13 @@ export struct RNSScreenTitleHeader {
         Row() {
             if (!this.isFirstScreenInStack && !this.hideBackButton) {
             Row() {
-              SymbolGlyph($r('sys.symbol.arrow_left')).fontSize(26).fontColor([this.titleColorValue])
+              SymbolGlyph($r('sys.symbol.arrow_left')).fontSize(26).fontColor([this.hintColor]).visibility(this.backButtonInCustomView?Visibility.Visible:Visibility.None)
 
               if (this.backTitleVisible) {
                 Text(this.backTitle ? this.backTitle : '')
                   .fontFamily(this.backTitleFontFamily)
                   .fontSize(this.backTitleFontSize ? this.backTitleFontSize : 18)
-                  .fontColor(this.titleColorValue)
+                  .fontColor(this.hintColor)
                   .margin({ left: this.hideBackButton ? 0 : 5, right: (this.backTitleVisible && this.backTitle) ? 5 : 0 })
               }
             }.height(56)
@@ -209,7 +214,7 @@ export struct RNSScreenTitleHeader {
             .fontFamily(this.fontFamilyValue)
             .fontSize(this.titleFontSizeValue ? this.titleFontSizeValue : 18)
             .fontWeight(this.titleFontWeightValue ? this.titleFontWeightValue : FontWeight.Medium)
-            .fontColor(this.titleColorValue)
+            .fontColor(this.titleColorValue?this.titleColorValue:this.hintColor)
             .textAlign(TextAlign.Start)
         }
         .width("100%")

--- a/tester/harmony/screens/src/main/ets/components/RNSSearchBar.ets
+++ b/tester/harmony/screens/src/main/ets/components/RNSSearchBar.ets
@@ -49,6 +49,7 @@ export struct RNSSearchBar {
   @State cancelButtonText: string | undefined = undefined;
   @State headerIconColor: string | undefined = undefined
   @State shouldShowHintSearchIcon: boolean = true;
+  @State tintColor: string = '';
   private cleanupCommandCallback?: () => void = undefined;
 
   aboutToAppear() {
@@ -118,7 +119,8 @@ export struct RNSSearchBar {
     }
     this.cancelButtonText = this.descriptor.rawProps["cancelButtonText"] || 'cancel';
     this.headerIconColor = this.descriptor.rawProps["headerIconColor"];
-    this.shouldShowHintSearchIcon = this.descriptor.rawProps["shouldShowHintSearchIcon"]
+    this.shouldShowHintSearchIcon = this.descriptor.rawProps["shouldShowHintSearchIcon"];
+    this.tintColor = this.descriptor.rawProps["tintColor"];
   }
 
   aboutToDisappear() {
@@ -154,6 +156,7 @@ export struct RNSSearchBar {
             Search({ placeholder: this.placeholder, value: this.text })
               .layoutWeight(1)
               .fontColor(this.fontColor)
+              .caretStyle({color: this.tintColor})
               .placeholderColor(this.hintTextColor)
               .searchIcon({ color: this.headerIconColor, size: this.shouldShowHintSearchIcon?16:0 })
               .backgroundColor(this.backgroundColorValue)
@@ -177,6 +180,7 @@ export struct RNSSearchBar {
               })
             .id("search")
             Text(this.cancelButtonText)
+              .fontColor(this.tintColor)
               .padding({ left: 5 })
               .visibility(this.cancelIconVisiblilty)
               .onClick((e) => {


### PR DESCRIPTION


# Summary

feat: screens库RNSSearchBar的tintColor属性，RNSScreenStackHeaderConfig的color属性，RNSScreen的onHeaderBackButtonClicked回调功能补充实现



## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

