### PR TITLE
feat: 设置color和titleColor的默认颜色，修改blurEffect属性生效条件

### DIFF
--- a/tester/harmony/screens/src/main/ets/components/RNSScreen.ets
+++ b/tester/harmony/screens/src/main/ets/components/RNSScreen.ets
@@ -34,7 +34,7 @@ import { CustomTransitionCoordinator } from '../animations/CustomTransition';
 import { RNSScreenStackHeaderConfigDescriptor } from './RNSScreenStackHeaderConfig';
 import { window } from '@kit.ArkUI';
 import { AnimationHandlerEvent, getNewAnimationState } from '../animations/AnimationHandler';
-import { RNSScreenTitleHeader } from "./RNSScreenTitleHeader"
+import { RNSScreenTitleHeader, hasTransparency } from "./RNSScreenTitleHeader"
 import { TITLEBAR_HEIGHT } from '../Constants';
 import common from '@ohos.app.ability.common';
 import { RNSScreenStack } from './RNSScreenStack'
@@ -126,6 +126,7 @@ export struct RNSScreen {
   @State sheetElevation: number = 0;
   @State blurEffect: 'none' | 'extraLight' | 'light' | 'dark' | 'regular' | 'prominent' | 'systemUltraThinMaterial' | 'systemThinMaterial' | 'systemMaterial' | 'systemThickMaterial' | 'systemChromeMaterial' | 'systemUltraThinMaterialLight' | 'systemThinMaterialLight' | 'systemMaterialLight' | 'systemThickMaterialLight' | 'systemChromeMaterialLight' | 'systemUltraThinMaterialDark' | 'systemThinMaterialDark' | 'systemMaterialDark' | 'systemThickMaterialDark' | 'systemChromeMaterialDark' = 'none';
   @State blueStyle: BlurStyle = BlurStyle.NONE;
+  @State isTranslate: boolean = false; // 背景色是否有alpha透明度
 
   @State offsetX: number = 0;
   @State offsetY: number = 0;
@@ -335,6 +336,7 @@ export struct RNSScreen {
       this.blurEffect = this.screenStackHeaderConfigDescriptor.rawProps["blurEffect"];
     }
 
+    this.isTranslate = hasTransparency(this.titleBarBgColor);
     this.blurEffectConvert();
     this.updateNativeHeaderHeight();
   }
@@ -610,7 +612,7 @@ export struct RNSScreen {
       RNViewBase({ ctx: this.ctx, tag: this.tag }) {
         Stack() {
           if(this.isStatusBarShow) {
-            Text('').height(this.statusBarHeight).width('100%').backgroundColor(this.titleBarBgColor).position({x:0, y:0}).backgroundBlurStyle(this.blueStyle)
+            Text('').height(this.statusBarHeight).width('100%').backgroundColor(this.titleBarBgColor).position({x:0, y:0}).backgroundBlurStyle(this.isTranslate?this.blueStyle:BlurStyle.NONE)
           }
 
           Stack(){

--- a/tester/harmony/screens/src/main/ets/components/RNSScreenTitleHeader.ets
+++ b/tester/harmony/screens/src/main/ets/components/RNSScreenTitleHeader.ets
@@ -51,6 +51,8 @@ export struct RNSScreenTitleHeader {
   @State blurEffect: 'none' | 'extraLight' | 'light' | 'dark' | 'regular' | 'prominent' | 'systemUltraThinMaterial' | 'systemThinMaterial' | 'systemMaterial' | 'systemThickMaterial' | 'systemChromeMaterial' | 'systemUltraThinMaterialLight' | 'systemThinMaterialLight' | 'systemMaterialLight' | 'systemThickMaterialLight' | 'systemChromeMaterialLight' | 'systemUltraThinMaterialDark' | 'systemThinMaterialDark' | 'systemMaterialDark' | 'systemThickMaterialDark' | 'systemChromeMaterialDark' = 'none';
   @State blueStyle: BlurStyle = BlurStyle.NONE;
   @State hintColor: string | undefined = undefined;
+  @State isTranslate: boolean = false; // 背景色是否有alpha透明度
+
   private cleanUpCallbacks: (() => void)[] = []
   public backBtnPressed: () => void = () => {
   }
@@ -112,6 +114,7 @@ export struct RNSScreenTitleHeader {
       }
     }
   }
+
   updateState() {
     if (!this.descriptor) {
       return
@@ -139,9 +142,6 @@ export struct RNSScreenTitleHeader {
     }
     if (this.titleFontWeightValue !== this.descriptor.rawProps["titleFontWeight"]) {
       this.titleFontWeightValue = this.descriptor.rawProps["titleFontWeight"]
-    }
-    if (this.titleColorValue !== this.descriptor.rawProps["titleColor"]) {
-      this.titleColorValue = this.descriptor.rawProps["titleColor"]
     }
     if (this.backgroundColorValue !== this.descriptor.rawProps["backgroundColor"]) {
       this.backgroundColorValue = this.descriptor.rawProps["backgroundColor"] || "#ffffff"
@@ -179,10 +179,17 @@ export struct RNSScreenTitleHeader {
       this.blurEffect = this.descriptor.rawProps["blurEffect"];
     }
 
-    if (this.hintColor !== this.descriptor.rawProps["color"]) {
-      this.hintColor = this.descriptor.rawProps["color"]
+    let tmpColor: string | undefined  = this.descriptor.rawProps["color"];
+    if (this.hintColor !== tmpColor) {
+      this.hintColor = tmpColor;
     }
 
+    let tmpTitleColor: string | undefined  = this.descriptor.rawProps["titleColor"];
+    if (this.titleColorValue !== tmpTitleColor) {
+      this.titleColorValue = tmpTitleColor;
+    }
+
+    this.isTranslate = hasTransparency(this.backgroundColorValue);
     this.blurEffectConvert();
   }
 
@@ -243,7 +250,7 @@ export struct RNSScreenTitleHeader {
       .layoutWeight(1)
       .padding({ left: 10, right: 10 })
       .backgroundColor(this.titleBarTranslucent?Color.Transparent:this.backgroundColorValue)
-      .backgroundBlurStyle(this.blueStyle)
+      .backgroundBlurStyle(this.isTranslate?this.blueStyle:BlurStyle.NONE)
 
       Text('')
         .width("100%")
@@ -261,4 +268,45 @@ export struct RNSScreenTitleHeader {
     .layoutWeight(1)
     .hitTestBehavior(HitTestMode.Transparent)
   }
+}
+
+export function hasTransparency(color: string| undefined): boolean {
+  if (!!!color) {
+    return false;
+  }
+  // 移除所有空格并转为小写
+  const normalizedColor = color.replace(/\s/g, '').toLowerCase();
+
+  // 检查 RGBA
+  const rgbaMatch = normalizedColor.match(/rgba\([^)]+,\s*([\d.]+)\)/);
+  if (rgbaMatch) {
+    return parseFloat(rgbaMatch[1]) < 1;
+  }
+
+  // 检查 HSLA
+  const hslaMatch = normalizedColor.match(/hsla\([^)]+,\s*([\d.]+)\)/);
+  if (hslaMatch) {
+    return parseFloat(hslaMatch[1]) < 1;
+  }
+
+  // 检查 8 位 HEX
+  const hexMatch = normalizedColor.match(/^#([a-f0-9]{8})$/);
+  if (hexMatch) {
+    const alphaHex = hexMatch[1].substring(6, 8);
+    return parseInt(alphaHex, 16) < 255;
+  }
+
+  // 检查 4 位 HEX（简写格式）
+  const shortHexMatch = normalizedColor.match(/^#([a-f0-9]{4})$/);
+  if (shortHexMatch) {
+    const alphaHex = shortHexMatch[1].charAt(3) + shortHexMatch[1].charAt(3);
+    return parseInt(alphaHex, 16) < 255;
+  }
+
+  if (normalizedColor === 'translate') {
+    return true;
+  }
+
+  // 没有透明度信息或格式不支持
+  return false;
 }


### PR DESCRIPTION

# Summary

feat: 设置color和titleColor的默认颜色，修改blurEffect属性生效条件

## Test Plan
<img width="265" height="572" alt="image" src="https://github.com/user-attachments/assets/9b5a6667-306f-4218-980a-938e7a620185" />
<img width="266" height="576" alt="image" src="https://github.com/user-attachments/assets/3d4bdff3-dba0-4dd5-8ac0-b69308c55817" />



## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

