### PR TITLE
fix: 修复结合native-stack使用在折叠屏pura x小屏中首次进入页面显示白屏问题

### DIFF
--- a/tester/harmony/screens/src/main/ets/components/RNSScreenStack.ets
+++ b/tester/harmony/screens/src/main/ets/components/RNSScreenStack.ets
@@ -311,16 +311,14 @@ export struct RNSScreenStack {
 
   build() {
     Stack() {
-      if (!this.isFirstNavigator || this.topInset !== 0) {
-        Navigation(this.stackController)
-          .mode(NavigationMode.Stack)
-          .navDestination(this.navDestinationBuilder)
-          .titleMode(NavigationTitleMode.Mini)
-          .hitTestBehavior(HitTestMode.Transparent)
-          .hideNavBar(true)
-          .customNavContentTransition((from: NavContentInfo, to: NavContentInfo,
-            operation: NavigationOperation) => this.customNavContentTransitionHandler(from, to, operation))
-      }
+      Navigation(this.stackController)
+        .mode(NavigationMode.Stack)
+        .navDestination(this.navDestinationBuilder)
+        .titleMode(NavigationTitleMode.Mini)
+        .hitTestBehavior(HitTestMode.Transparent)
+        .hideNavBar(true)
+        .customNavContentTransition((from: NavContentInfo, to: NavContentInfo,
+          operation: NavigationOperation) => this.customNavContentTransitionHandler(from, to, operation))
     }
   }
 }


### PR DESCRIPTION


# Summary

fix: 修复结合native-stack使用在折叠屏pura x小屏中首次进入页面显示白屏问题


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

