### PR TITLE
fix: resolve screenId type error with type assertion

### DIFF
--- a/react-native-harmony-screens/src/components/ScreenStackItem.tsx
+++ b/react-native-harmony-screens/src/components/ScreenStackItem.tsx
@@ -141,7 +141,7 @@ function ScreenStackItem(
           currentRefs[screenId] = { current: node };
         }
       }}
-      screenId={screenId}
+      {...({ screenId } as any)}
       enabled
       isNativeStack
       activityState={activityState}


### PR DESCRIPTION
# Summary

Fix TypeScript build error: `Property 'screenId' does not exist on type 'ScreenProps'`.

## Test Plan

```bash
react-native-harmony-screens|br_rnoh0.77⚡ ⇒  bun run prepack
$ bob build
ℹ Building target commonjs
ℹ Cleaning up previous build at lib/commonjs
ℹ Compiling 28 files in src with babel
✔ Wrote files to lib/commonjs
ℹ Building target module
ℹ Cleaning up previous build at lib/module
ℹ Compiling 28 files in src with babel
✔ Wrote files to lib/module
ℹ Building target typescript
ℹ Cleaning up previous build at lib/typescript
ℹ Generating type definitions with tsc
✔ Wrote definition files to lib/typescript

```

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I have already compared the effects/features with the Android or iOS platforms
- [ ] I added a test for the API (if applicable)
- [ ] I have updated the JS/TS (if applicable)
- [ ] I updated the documentation (if applicable)
